### PR TITLE
fix: upgrade phone rule to get only phone keyworld

### DIFF
--- a/rules/sources/contact_data.yaml
+++ b/rules/sources/contact_data.yaml
@@ -25,7 +25,7 @@ sources:
     isSensitive: False
     sensitivity: medium
     patterns:
-      - "(?i)((phone|mobile|cellphone|contact)|.*(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
+      - "(?i)(((^(?!\s*$))(phone|mobile|cellphone|contact))|.*(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
     tags:
       law: GDPR
   

--- a/rules/sources/contact_data.yaml
+++ b/rules/sources/contact_data.yaml
@@ -25,7 +25,7 @@ sources:
     isSensitive: False
     sensitivity: medium
     patterns:
-      - "(?i).*((phone|mobile|cellphone|contact)|(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
+      - "(?i)((phone|mobile|cellphone|contact)|.*(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
     tags:
       law: GDPR
   

--- a/rules/sources/contact_data.yaml
+++ b/rules/sources/contact_data.yaml
@@ -25,7 +25,7 @@ sources:
     isSensitive: False
     sensitivity: medium
     patterns:
-      - "(?i).*((phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
+      - "(?i).*((phone|mobile|cellphone|contact)|(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
     tags:
       law: GDPR
   

--- a/rules/sources/contact_data.yaml
+++ b/rules/sources/contact_data.yaml
@@ -25,7 +25,7 @@ sources:
     isSensitive: False
     sensitivity: medium
     patterns:
-      - "(?i)(((^(?!\s*$))(phone|mobile|cellphone|contact))|.*(phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))"
+      - "(?i)((phone|mobile|cellphone|contact)|(.*((phone|mobile|cellphone|contact)[^\\s/(;)#|,=!>]{0,2}(?:detail|details)|(?:mobile|phone|cellphone|contact)[^\\s/(;)#|,=!>]{0,10}(?:number|nbr|num|no)|(?:primary|secondary)[^\\s/(;)#|,=!>]{0,10}(phone|landline|telephone))))"
     tags:
       law: GDPR
   


### PR DESCRIPTION
There's a small problem with the phone rule. In case the field is called phoneDetail will check correctly, but in case the field is just phone the regex would not get it.