### PR TITLE
Track mnemonic used in digital wallets

### DIFF
--- a/rules/sources/account_data.yaml
+++ b/rules/sources/account_data.yaml
@@ -39,6 +39,16 @@ sources:
     tags:
       law: GDPR
 
+  - id: Data.Sensitive.AccountData.Mnemonic
+    name: Mnemonic
+    category: Account Data
+    isSensitive: False
+    sensitivity: high
+    patterns:
+      - "(?i).*(mnemonic)"
+    tags:
+      law: GDPR
+
   - id: Data.Sensitive.AccountData.AccountName
     name: Account Name
     category: Account Data


### PR DESCRIPTION
Added a new rule for tracking mnemonics used commonly in bitcoin wallets. Verified that it works using `privado scan BitcoinWallet -i -c /path/to/modified/privado`

![image](https://user-images.githubusercontent.com/3373857/190242761-7ab4487e-b8ee-46c6-85b9-282569a41880.png)
