### PR TITLE
Update the API sink rule & exclude python packages

### DIFF
--- a/config/exclusions/python.yaml
+++ b/config/exclusions/python.yaml
@@ -4,6 +4,11 @@ exclusions:
     patterns:
       - "(.*/test(s)?.*)|/Test[A-Z]|Test[.]"
 
+  - id: Exclusions.Python.Packages
+    name: Exclude External Python Packages
+    patterns:
+      - "(venv|site-packages)/.*"
+
   - id: Exclusions.Empty
     name: Exclude file which cannot be read
     patterns:

--- a/config/systemConfig/python.yaml
+++ b/config/systemConfig/python.yaml
@@ -6,4 +6,4 @@ systemConfig:
     value: (?i)(?:url(?!(open|encode))|client|get|set|post|put|patch|delete|head|options|request|feed|trigger|init|find|send|receive|redirect|fetch|execute|response|pool|client|http|load|list|trace|remove|write|provider|host|access|info_read|select|perform).*
 
   - key: apiIdentifier
-    value: (?i).*((hook|base|authorize|provider|endpoint|installation|cloud|host)(s){0,1}_url|(slack|web)_hook|(rest|api|host|cloud)_endpoint).*
+    value: (?i).*((hook|base|auth|prov|endp|install|cloud|host|request|service|gateway|route|resource)(.){0,12}url|(slack|web)(.){0,4}hook|(rest|api|host|cloud|request|service)(.){0,4}(endpoint|gateway|route)).*


### PR DESCRIPTION
- Updated python API sink rule as per updated java rule
- Added site-packages, venv folders in exclusion for python