### PR TITLE
Ruby rules for leakages

### DIFF
--- a/rules/sinks/leakages/logs/ruby.yaml
+++ b/rules/sinks/leakages/logs/ruby.yaml
@@ -1,0 +1,30 @@
+sinks:
+  - id: Leakages.Log.Console
+    name: Log Console
+    patterns: 
+      - "(?i).*(puts|print|p|pp).*"
+    tags:
+
+  - id: Leakages.Log.Info
+    name: Log Info
+    patterns:
+      - "(?i).*(info|progname).*"
+    tags:
+
+  - id: Leakages.Log.Error
+    name: Log Error
+    patterns:
+      - "(?i).*(error|err|fatal).*"
+    tags:
+
+  - id: Leakages.Log.Warn
+    name: Log Warn
+    patterns:
+      - "(?i).*(warn|warning|[.]w[:]).*"
+    tags:
+
+  - id: Leakages.Log.Debug
+    name: Log Debug
+    patterns:
+      - "(?i).*(debug|trace).*"
+    tags:

--- a/rules/sinks/leakages/logs/ruby.yaml
+++ b/rules/sinks/leakages/logs/ruby.yaml
@@ -2,29 +2,29 @@ sinks:
   - id: Leakages.Log.Console
     name: Log Console
     patterns: 
-      - "(?i).*(puts|print|p|pp)"
+      - "(?i)(puts|print|p|pp)"
     tags:
 
   - id: Leakages.Log.Info
     name: Log Info
     patterns:
-      - "(?i).*(info|progname)"
+      - "(?i)(info|progname)"
     tags:
 
   - id: Leakages.Log.Error
     name: Log Error
     patterns:
-      - "(?i).*(error|err|fatal)"
+      - "(?i)(error|err|fatal)"
     tags:
 
   - id: Leakages.Log.Warn
     name: Log Warn
     patterns:
-      - "(?i).*(warn|warning|[.]w[:])"
+      - "(?i)(warn|warning|[.]w[:])"
     tags:
 
   - id: Leakages.Log.Debug
     name: Log Debug
     patterns:
-      - "(?i).*(debug|trace)"
+      - "(?i)(debug|trace)"
     tags:

--- a/rules/sinks/leakages/logs/ruby.yaml
+++ b/rules/sinks/leakages/logs/ruby.yaml
@@ -2,29 +2,29 @@ sinks:
   - id: Leakages.Log.Console
     name: Log Console
     patterns: 
-      - "(?i).*(puts|print|p|pp).*"
+      - "(?i).*(puts|print|p|pp)"
     tags:
 
   - id: Leakages.Log.Info
     name: Log Info
     patterns:
-      - "(?i).*(info|progname).*"
+      - "(?i).*(info|progname)"
     tags:
 
   - id: Leakages.Log.Error
     name: Log Error
     patterns:
-      - "(?i).*(error|err|fatal).*"
+      - "(?i).*(error|err|fatal)"
     tags:
 
   - id: Leakages.Log.Warn
     name: Log Warn
     patterns:
-      - "(?i).*(warn|warning|[.]w[:]).*"
+      - "(?i).*(warn|warning|[.]w[:])"
     tags:
 
   - id: Leakages.Log.Debug
     name: Log Debug
     patterns:
-      - "(?i).*(debug|trace).*"
+      - "(?i).*(debug|trace)"
     tags:


### PR DESCRIPTION
Rules are defined on the basis of names of call nodes atm.