### PR TITLE
Fix rule for line sdk in python

### DIFF
--- a/rules/sinks/third_parties/sdk/line/python.yaml
+++ b/rules/sinks/third_parties/sdk/line/python.yaml
@@ -9,5 +9,5 @@ sinks:
     domains:
       - "line.me"
     patterns:
-      - "(?i)(linebot|lotify|line_pay|lineapi|byteline_sdk|alerta|juq|Rev|clova_cek_sdk).*"
+      - "(?i)(linebot|lotify|line_pay|lineapi|byteline_sdk|alerta|rev_ai|clova_cek_sdk).*"
     tags:


### PR DESCRIPTION
rev is now changed to rev_ai. juq is a utility module, hence removed.