### PR TITLE
Do not match names are that are capitals + underscores

### DIFF
--- a/rules/sources/financial_data.yaml
+++ b/rules/sources/financial_data.yaml
@@ -25,7 +25,7 @@ sources:
     isSensitive: False
     sensitivity: high
     patterns:
-      - "(?i).*((?:credit|debit)[^\\s/(;)#|,=!>]{0,10}card[^\\s/(;)#|,=!>]{0,10}(number|no|num|nbr)|(?:credit|debit)[^\\s/(;)#|,=!>]{0,10}card)|cc[-_]{0,1}(number|num|nbr|no)"
+      - "(?![A-Z_]+)(?i).*((?:credit|debit)[^\\s/(;)#|,=!>]{0,10}card[^\\s/(;)#|,=!>]{0,10}(number|no|num|nbr)|(?:credit|debit)[^\\s/(;)#|,=!>]{0,10}card)|cc[-_]{0,1}(number|num|nbr|no)"
     tags:
       law: GDPR
 


### PR DESCRIPTION
Usually constant names are made up of capitals + underscores.

For e.g. "CREDIT_CARD" should not match but both "credit_card" or "creditCard" should match.