### PR TITLE
CA-234 | Add Kotlin collection support for Ktor and SparkJava

### DIFF
--- a/rules/collections/default/java.yaml
+++ b/rules/collections/default/java.yaml
@@ -1,0 +1,6 @@
+collections:
+  - id: Collections.SparkJava
+    name: SparkJava Http Framework
+    patterns:
+      - "(?i)Spark.(post|get|delete|put).*"
+    tags:

--- a/rules/collections/default/java.yaml
+++ b/rules/collections/default/java.yaml
@@ -2,5 +2,5 @@ collections:
   - id: Collections.SparkJava
     name: SparkJava Http Framework
     patterns:
-      - "(?i)Spark.(post|get|delete|put).*"
+      - "(?i)(spark.Spark).(post|get|delete|put).*"
     tags:

--- a/rules/collections/default/kotlin.yaml
+++ b/rules/collections/default/kotlin.yaml
@@ -1,0 +1,6 @@
+collections:
+  - id: Collections.Ktor
+    name: Ktor Kotlin Framework
+    patterns:
+      - "(?i)io.ktor.server.routing.(post|get|delete|put).*"
+    tags:


### PR DESCRIPTION
## Description

Adds support for both SparkJava - https://sparkjava.com/ and Ktor - https://ktor.io/ collection rules. 

This PR depends on the merge of [PR for kotlin collection support](https://github.com/Privado-Inc/privado-core/pull/969).

