### PR TITLE
Fix PR feedback for both JAX-RS annotation and Morphia (MongoDb client)

### DIFF
--- a/rules/collections/annotations/java.yaml
+++ b/rules/collections/annotations/java.yaml
@@ -29,14 +29,8 @@ collections:
       - "RemoteServiceRelativePath"
     tags:
 
-  - id: Collections.Annotation.Retrofit
-    name: Retrofit Interface Annotation
-    patterns:
-      - "GET|POST"
-    tags:
-
   - id: Collections.Annotation.JAX-RS
     name: JAX-RS Annotation
     patterns:
-      - "(?i)(javax.ws.rs).(GET|PUT|POST|DELETE|HEAD|OPTIONS).*"
+      - ".*(GET|PUT|POST|DELETE|HEAD|OPTIONS).*"
     tags:

--- a/rules/sinks/storages/mongodb/java.yaml
+++ b/rules/sinks/storages/mongodb/java.yaml
@@ -27,7 +27,7 @@ sinks:
       - mongodb.com
     patterns: 
       - "(?i)(.*[.]morphia[.]Datastore)[.]((find|get|getByKey|getByKeys|getCount|createAggregation|createQuery|queryByExample|exists).*[:].*)"
-      - "(?i)(.*[.]morphia[.]query[.](asList|countAll|count|get).*)"
+      - "(?i)(.*[.]morphia[.]query[.].Query[.](asList|countAll|count|get).*)"
     tags:
 
   - id: Storages.MongoDB.Morphia.Write
@@ -36,7 +36,8 @@ sinks:
       - mongodb.com
     patterns:
       - "(?i)(.*[.]morphia[.]Datastore)[.]((save|update|updateFirst|createUpdateOperations|delete|findAnd(Delete|Modify)|merge).*[:].*)"
-      - "(?i)(.*[.]morphia[.]query[.](FieldEnd|modify|execute|delete).*)"
+      - "(?i)(.*[.]morphia[.]query[.](FieldEnd).*)"
+      - "(?i)(.*[.]morphia[.]query[.].Query[.](modify|execute|delete).*)"
     tags:
     
   - id: Storages.MongoDB.SpringRepository.Read


### PR DESCRIPTION
- fixing Morphia package name, it was wrong in earlier PR
- removing retrofit since JAX-RS is a common denominator for all Java EE http frameworks