### PR TITLE
fix - java exclusion rule

### DIFF
--- a/config/exclusions/java.yaml
+++ b/config/exclusions/java.yaml
@@ -2,7 +2,7 @@ exclusions:
   - id: Exclusions.Test
     name: Exclude test source code
     patterns:
-      - "(.*/src/test/.*)|/Test[A-Z]|Test[.]"
+      - "(.*/test/.*)|/Test[A-Z]|Test[.]"
   
   - id: Exclusions.Invalid.Properties
     name: Exclude invalid properties file


### PR DESCRIPTION
The exclusion rule is matching on the relative path of the file, for case like `src/test` regex of `.*/src/test.*` will fail, change that to match files having a folder named `test` in there path