### PR TITLE
fix: correct sdk sink names for third parties (#443)

### DIFF
--- a/rules/sinks/storages/astradb/java.yml
+++ b/rules/sinks/storages/astradb/java.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.AstraDB
+    name: AstraDB
+    domains:
+      - "docs.datastax.com"
+    patterns:
+      - "(?i)(com[.]datastax[.]astra).*"
+    tags:

--- a/rules/sinks/storages/astradb/javascript.yml
+++ b/rules/sinks/storages/astradb/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.AstraDB
+    name: AstraDB
+    domains:
+      - "datastax.com"
+    patterns:
+      - "@datastax\\/astra-db-ts"
+    tags:

--- a/rules/sinks/storages/astradb/python.yml
+++ b/rules/sinks/storages/astradb/python.yml
@@ -1,0 +1,15 @@
+sinks:
+  - id: Storages.AstraDB.Initialize
+    name: AstraDB DB
+    domains:
+      - datastax.com
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.AstraDB).*"
+
+  - id: Storages.AstraDB.ReadAndWrite
+    name: Astra DB
+    domains:
+      - datastax.com
+    patterns:
+      - (?i).*(astrapy).*(?:create_collection|insert_many|vector_find).*
+    tags:

--- a/rules/sinks/storages/chromadb/javascript.yml
+++ b/rules/sinks/storages/chromadb/javascript.yml
@@ -1,0 +1,12 @@
+
+# Sink Rules for storage database ChromaDB - trychroma.com
+
+sinks:
+
+  - id: Storages.Chroma.ReadAndWrite
+    name: Chroma VectorDB
+    domains:
+      - trychroma.com
+    patterns:
+      - "(?i)(chromadb).*"
+    tags:

--- a/rules/sinks/storages/chromadb/python.yml
+++ b/rules/sinks/storages/chromadb/python.yml
@@ -1,0 +1,33 @@
+
+# Sink Rules for vector DB ChromaDB
+
+sinks:
+  - id: Storages.Chroma.Initialize
+    name: Chroma DB
+    domains:
+      - trychroma.com
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Chroma).*"
+
+  - id: Storages.Chroma.Client
+    name: Chroma DB
+    domains:
+      - trychroma.com
+    patterns:
+      - "(?i).*(?:chromadb).*(?:HttpClient).*"
+
+  - id: Storages.Chroma.Read
+    name: Chroma DB (Read)
+    domains:
+      - trychroma.com
+    patterns:
+      - "(?i).*(?:chromadb).*(?:search|query|get_collection).*"
+    tags:
+
+  - id: Storages.Chroma.Write
+    name: Chroma DB (Write)
+    domains:
+      - trychroma.com
+    patterns:
+      - "(?i).*(?:chromadb).*(?:add|insert|do_bulk_insert|update|upsert|create_collection).*"
+    tags:

--- a/rules/sinks/storages/cosmosdb/python.yaml
+++ b/rules/sinks/storages/cosmosdb/python.yaml
@@ -2,6 +2,13 @@
 # Sink Rules for storage database Azure Cosmos DB - https://azure.microsoft.com/en-us/services/cosmos-db/
 
 sinks:
+  - id: Storages.AzureCosmosDb.Initialize
+    name: Azure Cosmos DB
+    domains:
+      - azure.microsoft.com
+      - microsoft.com
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.AzureCosmosDBVectorSearch).*"
 
   - id: Storages.AzureCosmosDb
     name: Azure Cosmos DB

--- a/rules/sinks/storages/deeplake/python.yml
+++ b/rules/sinks/storages/deeplake/python.yml
@@ -1,0 +1,18 @@
+
+# Sink Rules for vector DB Deeplake
+
+sinks:
+  - id: Storages.Deeplake.Initialize
+    name: Deeplake DB
+    domains:
+      - activeloop.ai
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.DeepLake).*"
+
+  - id: Storages.Deeplake.ReadAndWrite
+    name: Deeplake DB
+    domains:
+      - activeloop.ai
+    patterns:
+      - (?i).*(deeplake).*(?:load|add|search).*
+    tags:

--- a/rules/sinks/storages/elasticsearch/python.yaml
+++ b/rules/sinks/storages/elasticsearch/python.yaml
@@ -2,6 +2,12 @@
 # Sink Rules for storage database Elasticsearch - https://www.elastic.co/elasticsearch/
 
 sinks:
+  - id: Storages.Elasticsearch.Initialize
+    name: Elasticsearch(Initialize)
+    domains:
+      - elastic.co
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.ElasticsearchStore).*"
 
   - id: Storages.Elasticsearch.Read
     name: Elasticsearch(Read)

--- a/rules/sinks/storages/lance/python.yml
+++ b/rules/sinks/storages/lance/python.yml
@@ -1,0 +1,26 @@
+
+# Sink Rules for vector DB ChromaDB
+
+sinks:
+  - id: Storages.Lance.Initialize
+    name: Lance DB
+    domains:
+      - https://lancedb.com/
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.LanceDB).*"
+
+  - id: Storages.Lance.Read
+    name: Lance DB (Write)
+    domains:
+      - https://lancedb.com/
+    patterns:
+      - "(?i).*(?:lancedb.db).*(?:open_table|search).*"
+    tags:
+
+  - id: Storages.Lance.Write
+    name: Lance DB (Write)
+    domains:
+      - https://lancedb.com/
+    patterns:
+      - "(?i).*(?:lancedb.db).*(?:add|create_table|create_index|delete|drop_table).*"
+    tags:

--- a/rules/sinks/storages/milvus/java.yml
+++ b/rules/sinks/storages/milvus/java.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Milvus
+    name: Milvus
+    domains:
+      - "milvus.io"
+    patterns:
+      - "(?i)(io[.]milvus).*"
+    tags:

--- a/rules/sinks/storages/milvus/javascript.yml
+++ b/rules/sinks/storages/milvus/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Milvus
+    name: Milvus
+    domains:
+      - "milvus.io"
+    patterns:
+      - "@zilliz\\/milvus2-sdk-node"
+    tags:

--- a/rules/sinks/storages/milvus/python.yml
+++ b/rules/sinks/storages/milvus/python.yml
@@ -1,0 +1,26 @@
+
+# Sink Rules for vector DB Milvus
+
+sinks:
+  - id: Storages.Milvus.Initialize
+    name: Milvus DB
+    domains:
+      - milvus.io
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Milvus).*"
+
+  - id: Storages.Milvus.Read
+    name: Milvus DB (Read)
+    domains:
+      - milvus.io
+    patterns:
+      - "(?i).*(?:pymilvus).*(?:search|query).*"
+    tags:
+
+  - id: Storages.Milvus.Write
+    name: Milvus DB (Write)
+    domains:
+      - milvus.io
+    patterns:
+      - "(?i).*(?:pymilvus).*(?:insert|do_bulk_insert|upsert).*"
+    tags:

--- a/rules/sinks/storages/mongodb/python.yaml
+++ b/rules/sinks/storages/mongodb/python.yaml
@@ -2,6 +2,12 @@
 # Sink Rules for storage database MongoDB - https://www.mongodb.com/
 
 sinks:
+  - id: Storages.MongoDB.Initialize
+    name: MongoDB DB
+    domains:
+      - mongodb.com
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.MongoDBAtlasVectorSearch).*"
 
   - id: Storages.MongoDB.Read
     name: MongoDB(Read)

--- a/rules/sinks/storages/opensearch/python.yml
+++ b/rules/sinks/storages/opensearch/python.yml
@@ -1,0 +1,10 @@
+
+# Sink Rules for vector DB Opensearch
+
+sinks:
+  - id: Storages.OpenSearch.Initialize
+    name: OpenSearch DB
+    domains:
+      - https://opensearch.org/
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.OpenSearchVectorSearch).*"

--- a/rules/sinks/storages/pinecone/javascript.yml
+++ b/rules/sinks/storages/pinecone/javascript.yml
@@ -1,0 +1,12 @@
+
+# Sink Rules for storage database Pinecone - pinecone.io
+
+sinks:
+
+  - id: Storages.Pinecone.ReadAndWrite
+    name: Pinecone VectorDB
+    domains:
+      - pinecone.io
+    patterns:
+      - "(?i)(pinecone-database|pinecone).*"
+    tags:

--- a/rules/sinks/storages/pinecone/python.yml
+++ b/rules/sinks/storages/pinecone/python.yml
@@ -1,0 +1,26 @@
+
+# Sink Rules for vector DB Pinecone
+
+sinks:
+  - id: Storages.Pinecone.Initialize
+    name: Pinecone DB
+    domains:
+      - pinecone.io
+    patterns:
+      - "(?i).*(?:langchain.*.Pinecone).*"
+
+  - id: Storages.Pinecone.Read
+    name: Pinecone DB (Read)
+    domains:
+      - pinecone.io
+    patterns:
+      - "(?i).*(?:pinecone).*(?:fetch|query).*"
+    tags:
+
+  - id: Storages.Pinecone.Write
+    name: Pinecone DB (Write)
+    domains:
+      - pinecone.io
+    patterns:
+      - "(?i).*(?:pinecone).*(?:upsert|update).*"
+    tags:

--- a/rules/sinks/storages/qdrant/javascript.yml
+++ b/rules/sinks/storages/qdrant/javascript.yml
@@ -1,0 +1,12 @@
+
+# Sink Rules for storage database Qdrant - qdrant.tech
+
+sinks:
+
+  - id: Storages.Qdrant.ReadAndWrite
+    name: Qdrant DB
+    domains:
+      - qdrant.tech
+    patterns:
+      - "@qdrant\\/js-client-rest"
+    tags:

--- a/rules/sinks/storages/qdrant/python.yml
+++ b/rules/sinks/storages/qdrant/python.yml
@@ -1,0 +1,26 @@
+
+# Sink Rules for vector DB Qdrant
+
+sinks:
+  - id: Storages.Qdrant.Initialize
+    name: Qdrant DB
+    domains:
+      - qdrant.tech
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Qdrant).*"
+
+  - id: Storages.Qdrant.Read
+    name: Qdrant DB (Read)
+    domains:
+      - qdrant.tech
+    patterns:
+      - "(?i).*(?:qdrant_client).*(?:query|search).*"
+    tags:
+
+  - id: Storages.Qdrant.Write
+    name: Qdrant DB (Write)
+    domains:
+      - qdrant.tech
+    patterns:
+      - "(?i).*(?:qdrant_client).*(?:upsert|add).*"
+    tags:

--- a/rules/sinks/storages/redis/python.yaml
+++ b/rules/sinks/storages/redis/python.yaml
@@ -1,4 +1,11 @@
 sinks:
+  - id: Storages.Redis.Initialize
+    name: Redis DB
+    domains:
+      - redis.io
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Redis).*"
+
   - id: Storages.Redis.Read
     name: Redis DB
     domains:

--- a/rules/sinks/storages/vald/java.yml
+++ b/rules/sinks/storages/vald/java.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Vald
+    name: Vald
+    domains:
+      - "vald.vdaas.org"
+    patterns:
+      - "(?i)(org[.]vdaas[.]vald).*"
+    tags:

--- a/rules/sinks/storages/vald/javascript.yml
+++ b/rules/sinks/storages/vald/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Vald
+    name: Vald
+    domains:
+      - "vald.vdaas.org"
+    patterns:
+      - "(?i)(vald-client-node).*"
+    tags:

--- a/rules/sinks/storages/vald/python.yml
+++ b/rules/sinks/storages/vald/python.yml
@@ -1,0 +1,15 @@
+sinks:
+  - id: Storages.Vald.Initialize
+    name: Vald DB
+    domains:
+      - vald.vdaas.org
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Vald).*"
+
+  - id: Storages.Vald.ReadAndWrite
+    name: Vald DB
+    domains:
+      - vald.vdaas.org
+    patterns:
+      - (?i).*(vald).*(?:Insert|Update|Upsert|Search|Remove).*
+    tags:

--- a/rules/sinks/storages/weaviate/python.yaml
+++ b/rules/sinks/storages/weaviate/python.yaml
@@ -2,6 +2,12 @@
 # Sink Rules for storage database Vaticle TypeDB - https://vaticle.com/typedb
 
 sinks:
+  - id: Storages.Weaviate.Initialize
+    name: Weaviate DB
+    domains:
+      - weaviate.io
+    patterns:
+      - "(?i).*(?:langchain.*vectorstores.*.Weaviate).*"
 
   - id: Storages.Weaviate.ReadAndWrite
     name: Weaviate VectorDB

--- a/rules/sinks/third_parties/sdk/amazon/csharp.yaml
+++ b/rules/sinks/third_parties/sdk/amazon/csharp.yaml
@@ -45,7 +45,7 @@ sinks:
     tags:
 
   - id: ThirdParties.SDK.Amazonaws.Kinesis
-    name: Amazon Aws Kinesis
+    name: Amazon AWS Kinesis
     domains:
       - "aws.amazon.com/kinesis/"
     patterns:

--- a/rules/sinks/third_parties/sdk/amazon/javascript.yaml
+++ b/rules/sinks/third_parties/sdk/amazon/javascript.yaml
@@ -138,7 +138,7 @@ sinks:
   - id: ThirdParties.SDK.Amazonaws.Auth
     name: Amazonaws Auth
     domains:
-      - "aws.amazon.com"
+      - "docs.aws.amazon.com/prescriptive-guidance/latest/modernization-net-applications-security/authentication.html"
     patterns:
       - "(?i)(react-oauth2-pkce|@cloudcomponents\\/cdk-cloudfront-authorization|@vue-toolkit\\/aws-auth|react-oauth2-pkce-temp|passwordless-auth|serverless-custom-auth-plugin|brewery-auth|graphql-workspace-authorizer-transformer|vault-auth-aws|aws-api-auth-policy|@pi-team-mn\\/aws-apigw-authorizer|awsauth|redis-connection-no-auth|@stinkstudios\\/cf-auth|api-gateway-auth-policy|@orcden\\/od-authentication|aws-apigw-authorizer|@engineal\\/aws-cdk-recaptcha-authorizer)"
     tags:

--- a/rules/sinks/third_parties/sdk/amazon/python.yaml
+++ b/rules/sinks/third_parties/sdk/amazon/python.yaml
@@ -799,7 +799,7 @@ sinks:
     tags:
 
   - id: ThirdParties.SDK.Amazon.Aws
-    name: Amazon AWS
+    name: Amazon Aws
     domains:
       - "aws.amazon.com"
     patterns:

--- a/rules/sinks/third_parties/sdk/amazonaws/java.yaml
+++ b/rules/sinks/third_parties/sdk/amazonaws/java.yaml
@@ -1359,7 +1359,7 @@ sinks:
   - id: ThirdParties.SDK.Amazonaws.AppRegistry
     name: Amazonaws App Registry
     domains:
-      - "aws.amazon.com"
+      - "docs.aws.amazon.com/servicecatalog/latest/arguide/intro-app-registry.html"
     patterns:
       - "(?i)(com[.]amazonaws[.]services[.]appregistry).*"
     tags:

--- a/rules/sinks/third_parties/sdk/anthropic/javascript.yml
+++ b/rules/sinks/third_parties/sdk/anthropic/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Anthropic
+    name: Anthropic
+    domains:
+      - "anthropic.com"
+    patterns:
+      - "@anthropic-ai\\/sdk"
+    tags:

--- a/rules/sinks/third_parties/sdk/anthropic/python.yml
+++ b/rules/sinks/third_parties/sdk/anthropic/python.yml
@@ -1,0 +1,20 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Anthropic
+    name: Langchain Anthropic model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatAnthropic).*"
+    tags:
+
+  - id: ThirdParties.SDK.Anthropic
+    name: Anthropic
+    domains:
+      - "anthropic.com"
+    patterns:
+      - "(?i)(anthropic).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/anyscale/python.yml
+++ b/rules/sinks/third_parties/sdk/anyscale/python.yml
@@ -1,0 +1,20 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Anyscale
+    name: Langchain Anyscale model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatAnyscale).*"
+    tags:
+
+  - id: ThirdParties.SDK.Anyscale
+    name: Anyscale
+    domains:
+      - "anyscale.com"
+    patterns:
+      - "(?i).*(anyscalesdk).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/azureai/python.yml
+++ b/rules/sinks/third_parties/sdk/azureai/python.yml
@@ -1,0 +1,28 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.AzureChatOpenAI
+    name: Langchain Azure model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.AzureChatOpenAI).*"
+    tags:
+
+  - id: ThirdParties.SDK.Langchain.ChatModels.AzureML
+    name: Langchain AzureML model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.AzureML).*"
+    tags:
+
+  - id: ThirdParties.SDK.AzureAI.AzureOpenAI
+    name: AzureAI
+    domains:
+      - "azure.com"
+    patterns:
+      - "(?i).*(AzureOpenAI).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/baichuan/python.yml
+++ b/rules/sinks/third_parties/sdk/baichuan/python.yml
@@ -1,0 +1,12 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Baichuan
+    name: Langchain Baichuan model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatBaichuan).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/bedrock/python.yml
+++ b/rules/sinks/third_parties/sdk/bedrock/python.yml
@@ -1,0 +1,12 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Bedrock
+    name: Langchain Bedrock model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.BedrockChat).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/cohere/python.yaml
+++ b/rules/sinks/third_parties/sdk/cohere/python.yaml
@@ -3,6 +3,13 @@
 #  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
 
 sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Cohere
+    name: Langchain Cohere model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatCohere).*"
+    tags:
 
   - id: ThirdParties.SDK.Cohere
     name: Cohere

--- a/rules/sinks/third_parties/sdk/google/javascript.yaml
+++ b/rules/sinks/third_parties/sdk/google/javascript.yaml
@@ -39,7 +39,7 @@ sinks:
   - id: ThirdParties.SDK.Google.TagManager
     name: Google Tag Manager
     domains:
-      - "analytics.google.com"
+      - "tagmanager.google.com"
     patterns:
       - "@analytics\\/google-tag-manager|gatsby-plugin-google-gtag|react-gtm-module"
     tags:
@@ -48,7 +48,7 @@ sinks:
     name: Google Tag Manager
     filterProperty: "code"
     domains:
-      - "analytics.google.com"
+      - "tagmanager.google.com"
     patterns:
       - "(?i)(.*[.])?(gtag|dataLayer.push)[(].*"
     tags:

--- a/rules/sinks/third_parties/sdk/google/php.yaml
+++ b/rules/sinks/third_parties/sdk/google/php.yaml
@@ -57,7 +57,7 @@ sinks:
   - id: ThirdParties.SDK.Google.TagManager
     name: Google Tag Manager
     domains:
-      - "analytics.google.com"
+      - "tagmanager.google.com"
     patterns:
       - "(?i).*(googletagmanager).*"
     tags:

--- a/rules/sinks/third_parties/sdk/huggingface/python.yml
+++ b/rules/sinks/third_parties/sdk/huggingface/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.HuggingFace
+    name: HuggingFace
+    domains:
+      - "huggingface.co"
+    patterns:
+      - "(?i).*(sagemaker.*huggingface).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/langchain/python.yml
+++ b/rules/sinks/third_parties/sdk/langchain/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Langchain
+    name: Langchain
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i)(langchain|langchain_openai).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/litellm/python.yml
+++ b/rules/sinks/third_parties/sdk/litellm/python.yml
@@ -1,0 +1,12 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.LiteLLM
+    name: Langchain LiteLLM model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatLiteLLM).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/llamaapi/javascript.yml
+++ b/rules/sinks/third_parties/sdk/llamaapi/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.LlamaAPI
+    name: LlamaAPI
+    domains:
+      - "llama-api.com"
+    patterns:
+      - "llamaai"
+    tags:

--- a/rules/sinks/third_parties/sdk/llamaapi/python.yml
+++ b/rules/sinks/third_parties/sdk/llamaapi/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.LlamaAPI
+    name: LlamaAPI
+    domains:
+      - "llama-api.com"
+    patterns:
+      - "(?i)(llamaapi).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/llamaindex/javascript.yml
+++ b/rules/sinks/third_parties/sdk/llamaindex/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.LlamaIndex
+    name: LlamaIndex
+    domains:
+      - "llamaindex.ai"
+    patterns:
+      - "llamaindex"
+    tags:

--- a/rules/sinks/third_parties/sdk/llamaindex/python.yml
+++ b/rules/sinks/third_parties/sdk/llamaindex/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.LlamaIndex
+    name: LlamaIndex
+    domains:
+      - "llamaindex.ai"
+    patterns:
+      - "(?i)(llama_index).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/mistral/javascript.yml
+++ b/rules/sinks/third_parties/sdk/mistral/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Mistral
+    name: Mistral
+    domains:
+      - "sdk.vercel.ai"
+    patterns:
+      - "@mistralai-ai\\/mistralai"
+    tags:

--- a/rules/sinks/third_parties/sdk/ollama/python.yml
+++ b/rules/sinks/third_parties/sdk/ollama/python.yml
@@ -1,0 +1,12 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.Ollama
+    name: Langchian Ollama model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatOllama).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/openai/python.yaml
+++ b/rules/sinks/third_parties/sdk/openai/python.yaml
@@ -3,7 +3,14 @@
 #  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
 
 sinks:
-  
+  - id: ThirdParties.SDK.Langchain.ChatModels.OpenAI
+    name: Langchain OpenAI model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatOpenAI).*"
+    tags:
+
   - id: ThirdParties.SDK.OpenAI
     name: OpenAI
     domains:

--- a/rules/sinks/third_parties/sdk/stabilityai/python.yml
+++ b/rules/sinks/third_parties/sdk/stabilityai/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.StabilityAI
+    name: StabilityAI
+    domains:
+      - "https://platform.stability.ai/"
+    patterns:
+      - "(?i).*(stability_sdk.*.StabilityInference).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/tensorflow/java.yml
+++ b/rules/sinks/third_parties/sdk/tensorflow/java.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Tensorflow
+    name: Tensorflow
+    domains:
+      - "tensorflow.org"
+    patterns:
+      - "(?i)(org[.]tensorflow).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/tensorflow/javascript.yml
+++ b/rules/sinks/third_parties/sdk/tensorflow/javascript.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Tensorflow
+    name: Tensorflow
+    domains:
+      - "tensorflow.org"
+    patterns:
+      - "@tensorflow\\/tfjs"
+    tags:

--- a/rules/sinks/third_parties/sdk/tensorflow/python.yml
+++ b/rules/sinks/third_parties/sdk/tensorflow/python.yml
@@ -1,0 +1,13 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+
+  - id: ThirdParties.SDK.Tensorflow
+    name: Tensorflow
+    domains:
+      - "tensorflow.org"
+    patterns:
+      - "(?i)(tensorflow).*"
+    tags:

--- a/rules/sinks/third_parties/sdk/vertexai/python.yml
+++ b/rules/sinks/third_parties/sdk/vertexai/python.yml
@@ -1,0 +1,12 @@
+
+#  Sink rule for ThirdParty SDK
+#  The id follows a format : "ThirdParties.SDK.<THIRD_PARTY_ORGANISATION>.<SUB_ORGANISATION_IF_APPLICABLE>"
+
+sinks:
+  - id: ThirdParties.SDK.Langchain.ChatModels.VertexAI
+    name: Langchain VertexAI model
+    domains:
+      - "langchain.com"
+    patterns:
+      - "(?i).*(?:langchain.*chat_models.*.ChatVertexAI).*"
+    tags:


### PR DESCRIPTION
* Add support for AI and vector DBs SDKs

* Drop redundant comment

* Rename `yml` files as per convention and add non-`py` SDK support

* Push missing files

* Rename `Langchain`'s `yml`

* Add storage SDKs: AstraDB, Deeplake, Qdrant, and Vald

* Fix minor issues

* Add LLM SDKs: AzureAI, Mistral, and StabilityAI

* LLM SDK: Add huggingface

* Move `milvus` rules to `storage` and rename file as appropriate

* Drop redundant `yml` for `milvus`

* Add: `lancedb`

* Add APIs from `langchain`'s `vectorstores`

* Add `langchain`'s `vectorstore` API for `lancedb`

* Add `langchain`'s APIs for chat models

* Quick fixes: address review comment and fix domain for `langchain`'s `Azure` model

* Remove `docs` prefix from `Deeplake`'s domain

* Add AI APIs: `anyscale`, `baichuan`, and `bedrock`

* Address review comments

* AudioData rule fix (#425) (#426)

* fix: correct sdk sink names for third parties

---------