### PR TITLE
PHP leakage rule

### DIFF
--- a/rules/sinks/leakages/logs/php.yaml
+++ b/rules/sinks/leakages/logs/php.yaml
@@ -1,0 +1,30 @@
+sinks:
+  - id: Leakages.Log.Critical
+    name: Log Critical
+    patterns:
+      - "(?i).*(?:log|logger)->.*(?:emergency|alert|critical).*"
+    tags:
+
+  - id: Leakages.Log.Error
+    name: Log Error
+    patterns:
+      - "(?i).*(?:log|logger)->.*(?:error).*"
+    tags:
+    
+  - id: Leakages.Log.Warn
+    name: Log Warn
+    patterns:
+      - "(?i).*(?:log|logger)->.*(?:warning).*"
+    tags:
+  
+  - id: Leakages.Log.Debug
+    name: Log Debug
+    patterns:
+      - "(?i).*(?:log|logger)->.*(?:debug).*"
+    tags:
+  
+  - id: Leakages.Log.Info
+    name: Log Info
+    patterns:
+      - "(?i).*(?:log|logger)->.*(?:info|notice).*"
+    tags:


### PR DESCRIPTION
PHP loggers implement the logging interface. This PR adds rules based on it.

Note: Autload functionality is still being worked on by the joern team.