### PR TITLE
Add PHP storage tagging rules

### DIFF
--- a/rules/sinks/storages/doctrine/php.yaml
+++ b/rules/sinks/storages/doctrine/php.yaml
@@ -5,14 +5,14 @@ sinks:
   - id: Storages.Doctrine.Interface.Initialize
     name: Doctrine Interface (Initialize)
     domains:
-      - <url>
+      - www.doctrine-project.org
     patterns:
       - "(?i).*(?:Doctrine\\\\ORM\\\\EntityManager).*(__construct)"
 
   - id: Storages.Doctrine.Interface.ReadAndWrite
     name: Doctrine Interface (Read and Write)
     domains:
-      - <url>
+      - www.doctrine-project.org
     patterns:
       - "(?i).*(?:Doctrine\\\\ORM\\\\EntityManager).*(getConnection|getMetadataFactory|getExpressionBuilder|beginTransaction|transactional|commit|rollback|getClassMetadata|createQuery|createNamedQuery|createNativeQuery|createNamedNativeQuery|createQueryBuilder|flush|find|getReference|getPartialReference|clear|close|persist|remove|refresh|detach|merge|copy|lock|getEventManager|create|insert|delete)"
     tags:

--- a/rules/sinks/storages/doctrine/php.yaml
+++ b/rules/sinks/storages/doctrine/php.yaml
@@ -1,0 +1,18 @@
+
+# Sink Rules for Doctrine DB Interface
+
+sinks:
+  - id: Storages.Doctrine.Interface.Initialize
+    name: Doctrine Interface (Initialize)
+    domains:
+      - <url>
+    patterns:
+      - "(?i).*(?:Doctrine\\\\ORM\\\\EntityManager).*(__construct)"
+
+  - id: Storages.Doctrine.Interface.ReadAndWrite
+    name: Doctrine Interface (Read and Write)
+    domains:
+      - <url>
+    patterns:
+      - "(?i).*(?:Doctrine\\\\ORM\\\\EntityManager).*(getConnection|getMetadataFactory|getExpressionBuilder|beginTransaction|transactional|commit|rollback|getClassMetadata|createQuery|createNamedQuery|createNativeQuery|createNamedNativeQuery|createQueryBuilder|flush|find|getReference|getPartialReference|clear|close|persist|remove|refresh|detach|merge|copy|lock|getEventManager|create|insert|delete)"
+    tags:

--- a/rules/sinks/storages/laravel/php.yml
+++ b/rules/sinks/storages/laravel/php.yml
@@ -9,7 +9,7 @@ sinks:
     patterns:
       - "(?i).*(?:\\\\Facades\\\\DB).*(connection)"
 
-  - id: Storages.Laravel.Face.ReadAndWrite
+  - id: Storages.Laravel.Facade.ReadAndWrite
     name: Laravel Facade (Read and Write)
     domains:
       - laravel.com

--- a/rules/sinks/storages/laravel/php.yml
+++ b/rules/sinks/storages/laravel/php.yml
@@ -7,12 +7,12 @@ sinks:
     domains:
       - laravel.com
     patterns:
-      - "(?i).*(?:\\\\Facades\\\\DB).*(connection)"
+      - "(?i).*(?:Illuminate\\\\Support\\\\Facades\\\\DB).*(connection)"
 
   - id: Storages.Laravel.Facade.ReadAndWrite
     name: Laravel Facade (Read and Write)
     domains:
       - laravel.com
     patterns:
-      - "(?i).*(?:\\\\Facades\\\\DB).*(select|selectResultSets|scalar|insert|prepareBindings|unprepared|statement|delete|update|transaction|commit|begin_transaction|rollBack)"
+      - "(?i).*(?:Illuminate\\\\Support\\\\Facades\\\\DB).*(select|selectResultSets|scalar|insert|prepareBindings|unprepared|statement|delete|update|transaction|commit|begin_transaction|rollBack|table)"
     tags:

--- a/rules/sinks/storages/laravel/php.yml
+++ b/rules/sinks/storages/laravel/php.yml
@@ -1,0 +1,18 @@
+
+# Sink Rules for Laravel DB Facade
+
+sinks:
+  - id: Storages.Laravel.Facade.Initialize
+    name: Laravel Facade (Initialize)
+    domains:
+      - laravel.com
+    patterns:
+      - "(?i).*(?:\\\\Facades\\\\DB).*(connection)"
+
+  - id: Storages.Laravel.Face.ReadAndWrite
+    name: Laravel Facade (Read and Write)
+    domains:
+      - laravel.com
+    patterns:
+      - "(?i).*(?:\\\\Facades\\\\DB).*(select|selectResultSets|scalar|insert|prepareBindings|unprepared|statement|delete|update|transaction|commit|begin_transaction|rollBack)"
+    tags:

--- a/rules/sinks/storages/mysql/php.yml
+++ b/rules/sinks/storages/mysql/php.yml
@@ -1,0 +1,26 @@
+
+# Sink Rules for MySQL
+
+sinks:
+  - id: Storages.MySQL.Initialize
+    name: MySQL DB (Initialize)
+    domains:
+      - mysql.com
+    patterns:
+      - "(?i).*(?:mysqli|mysql).*(construct|connect)"
+
+  - id: Storages.MySQL.ReadAndWrite
+    name: MySQL DB (Read and Write)
+    domains:
+      - mysql.com
+    patterns:
+      - "(?i).*(?:mysqli|mysql|PDO).*(affected_rows|create_db|drop_db|construct|query|prepare|execute|bindValue|bind_param|setAttribute|store_result|fetch_all|fetch_array|fetch_row|num_fields|num_rows|next_result)"
+    tags:
+
+  - id: Storages.MySQL.ClearResources
+    name: MySQL DB (Clear resources)
+    domains:
+      - mysql.com
+    patterns:
+      - "(?i).*(?:mysqli|mysql|PDO).*(free_result|close)"
+    tags:

--- a/rules/sinks/storages/postgres/php.yaml
+++ b/rules/sinks/storages/postgres/php.yaml
@@ -1,0 +1,26 @@
+
+# Sink Rules for PostgreSQL
+
+sinks:
+  - id: Storages.PostgreSQL.Initialize
+    name: PostgreSQL DB (Initialize)
+    domains:
+      - postgresql.org
+    patterns:
+      - "(?i).*(pg_connect|pg_connect_poll|pg_connection).*"
+
+  - id: Storages.PostgreSQL.ReadAndWrite
+    name: PostgreSQL DB (Read and Write)
+    domains:
+      - postgresql.org
+    patterns:
+      - "(?i).*(pg_query|pg_fetch|pg_field|pg_lo|pg_affected_rows|pg_num|pg_result|pg_set|pg_delete).*"
+    tags:
+
+  - id: Storages.PostgreSQL.ClearResources
+    name: PostgreSQL DB (Clear resources)
+    domains:
+      - postgresql.org
+    patterns:
+      - "(?i).*(pg_free_result|pg_close|pg_cancel_query)"
+    tags:


### PR DESCRIPTION
This PR adds storage tagging rules for:
1. MySQL (`mysqli`, `PDO`, and `mysql`),
2. PostgreSQL, and,
3. Laravel DB face.