### PR TITLE
fix: python packages exclusion rule - site-packages is a nested dir

### DIFF
--- a/config/exclusions/python.yaml
+++ b/config/exclusions/python.yaml
@@ -7,7 +7,7 @@ exclusions:
   - id: Exclusions.Python.Packages
     name: Exclude External Python Packages
     patterns:
-      - "(venv|site-packages)/.*"
+      - ".*/(venv|site-packages)/.*"
 
   - id: Exclusions.Empty
     name: Exclude file which cannot be read


### PR DESCRIPTION
python packages exclusion rule - site-packages is a nested directory