### PR TITLE
Remove default Braze rule for ruby

### DIFF
--- a/rules/sinks/third_parties/sdk/braze/ruby.yaml
+++ b/rules/sinks/third_parties/sdk/braze/ruby.yaml
@@ -1,9 +1,0 @@
-sinks:
-
-  - id: ThirdParties.SDK.Braze
-    name: Braze
-    domains:
-      - "braze.com"
-    patterns:
-      - "(?i)(braze(_ruby)?).*"
-    tags:


### PR DESCRIPTION
This rule is too wide and runs over dynamicTypeHintFullname which leads to over tagging. Removing this and placing a separate custom rule where needed.