### PR TITLE
fix: add missing import reto trufflehog-exception.py

### DIFF
--- a/trufflehog/trufflehog-exception.py
+++ b/trufflehog/trufflehog-exception.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 # Load patterns from the JSON file
 with open("./trufflehog/truffleHogAllowRules.json", "r") as f:


### PR DESCRIPTION
This PR fixes a bug in trufflehog-exception.py where the re module was used but not imported. This caused a NameError when running the script. The fix adds import re at the top of the file.
